### PR TITLE
Reconcile vpc endpoint

### DIFF
--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -53,7 +53,7 @@ const (
 	AwsVpcOperatorFinalizer = "aws-vpc-operator.finalizers.giantswarm.io"
 
 	VpcEndpointReady              capi.ConditionType = "VpcEndpointReady"
-	ClusterSecurityGroupsNotReady                    = "ClusterSecurityGroupsNotReady"
+	ClusterSecurityGroupsNotReady string             = "ClusterSecurityGroupsNotReady"
 )
 
 // AWSClusterReconciler reconciles a AWSCluster object

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -531,7 +531,7 @@ func (r *AWSClusterReconciler) reconcileNormal(ctx context.Context, logger logr.
 			return ctrl.Result{}, microerror.Mask(err)
 		}
 
-		if strings.ToLower(result.Status.VpcEndpointState) == strings.ToLower(vpcendpoint.StateAvailable) {
+		if strings.EqualFold(result.Status.VpcEndpointState, vpcendpoint.StateAvailable) {
 			capiconditions.MarkTrue(awsCluster, VpcEndpointReady)
 		} else {
 			reason := fmt.Sprintf("VpcEndpointState%s", result.Status.VpcEndpointState)

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -530,7 +531,7 @@ func (r *AWSClusterReconciler) reconcileNormal(ctx context.Context, logger logr.
 			return ctrl.Result{}, microerror.Mask(err)
 		}
 
-		if result.Status.VpcEndpointState == vpcendpoint.StateAvailable {
+		if strings.ToLower(result.Status.VpcEndpointState) == strings.ToLower(vpcendpoint.StateAvailable) {
 			capiconditions.MarkTrue(awsCluster, VpcEndpointReady)
 		} else {
 			reason := fmt.Sprintf("VpcEndpointState%s", result.Status.VpcEndpointState)

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -1,0 +1,27 @@
+package controllers
+
+import (
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+)
+
+const (
+	// deletionFailedReason is hard-coded in CAPA as a string literal, there is
+	// no const that we can reuse in our operator
+	deletionFailedReason = "DeletingFailed"
+)
+
+func isBeingDeleted(object capiconditions.Getter, condition capi.ConditionType) bool {
+	return capiconditions.IsFalse(object, condition) &&
+		capiconditions.GetReason(object, condition) == capi.DeletingReason
+}
+
+func isDeleted(object capiconditions.Getter, condition capi.ConditionType) bool {
+	return capiconditions.IsFalse(object, condition) &&
+		capiconditions.GetReason(object, condition) == capi.DeletedReason
+}
+
+func deletionFailed(object capiconditions.Getter, condition capi.ConditionType) bool {
+	return capiconditions.IsFalse(object, condition) &&
+		capiconditions.GetReason(object, condition) == deletionFailedReason
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.1
+	go.uber.org/zap v1.21.0
 	golang.org/x/text v0.3.7
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
@@ -79,7 +80,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"go.uber.org/zap/zapcore"
 	capa "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
@@ -67,6 +68,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/pkg/aws/routetables/client_create.go
+++ b/pkg/aws/routetables/client_create.go
@@ -31,7 +31,7 @@ func (c *client) Create(ctx context.Context, input CreateRouteTableInput) (outpu
 	logger.Info("Started creating route table")
 	defer func() {
 		if err == nil {
-			logger.Info("Finished creating route table")
+			logger.Info("Finished creating route table", "route-table-id", output.RouteTableId, "route-table-state", output.AssociationStateCode)
 		} else {
 			logger.Error(err, "Failed to create route table")
 		}

--- a/pkg/aws/routetables/client_delete.go
+++ b/pkg/aws/routetables/client_delete.go
@@ -90,7 +90,7 @@ func (c *client) DeleteAll(ctx context.Context, input DeleteRouteTablesInput) (e
 		return microerror.Maskf(errors.InvalidConfigError, "%T.Region must not be empty", input)
 	}
 	if input.VpcId == "" {
-		return microerror.Maskf(errors.InvalidConfigError, "%T.RouteTableId must not be empty", input)
+		return microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
 	}
 
 	listInput := ListRouteTablesInput(input)

--- a/pkg/aws/routetables/client_delete.go
+++ b/pkg/aws/routetables/client_delete.go
@@ -100,6 +100,10 @@ func (c *client) DeleteAll(ctx context.Context, input DeleteRouteTablesInput) (e
 	}
 
 	for _, routeTable := range listOutput {
+
+		if len(routeTable.AssociatedSubnets) > 0 {
+			logger.Info("Deleting subnet associations for route table", "route-table-id", routeTable.RouteTableId)
+		}
 		// first delete all existing route table associations
 		for _, association := range routeTable.AssociatedSubnets {
 			err = c.deleteRouteTableAssociation(ctx, input.RoleARN, input.Region, association.AssociationId)
@@ -107,12 +111,17 @@ func (c *client) DeleteAll(ctx context.Context, input DeleteRouteTablesInput) (e
 				return microerror.Mask(err)
 			}
 		}
+		if len(routeTable.AssociatedSubnets) > 0 {
+			logger.Info("Deleted subnet associations for route table", "route-table-id", routeTable.RouteTableId)
+		}
 
 		// then delete the route table itself
+		logger.Info("Deleting route table", "route-table-id", routeTable.RouteTableId)
 		err = c.deleteRouteTable(ctx, input.RoleARN, input.Region, routeTable.RouteTableId)
 		if err != nil {
 			return microerror.Mask(err)
 		}
+		logger.Info("Deleted route table", "route-table-id", routeTable.RouteTableId)
 	}
 
 	return nil

--- a/pkg/aws/routetables/client_list.go
+++ b/pkg/aws/routetables/client_list.go
@@ -58,6 +58,7 @@ func (c *client) List(ctx context.Context, input ListRouteTablesInput) (output L
 }
 
 func (c *client) listWithFilter(ctx context.Context, roleArn, region, filterName, filterValue string) (output ListRouteTablesOutput, err error) {
+	logger := log.FromContext(ctx)
 	ec2Input := ec2.DescribeRouteTablesInput{
 		Filters: []ec2Types.Filter{
 			{
@@ -71,7 +72,7 @@ func (c *client) listWithFilter(ctx context.Context, roleArn, region, filterName
 		return ListRouteTablesOutput{}, microerror.Mask(err)
 	}
 
-	output = make(ListRouteTablesOutput, len(ec2Output.RouteTables))
+	output = ListRouteTablesOutput{}
 	for _, ec2RouteTable := range ec2Output.RouteTables {
 		if ec2RouteTable.RouteTableId == nil || *ec2RouteTable.RouteTableId == "" {
 			continue
@@ -103,6 +104,7 @@ func (c *client) listWithFilter(ctx context.Context, roleArn, region, filterName
 		}
 
 		output = append(output, routeTableOutput)
+		logger.Info("Found route table", "route-table-id", routeTableOutput.RouteTableId, "route-table-tags", routeTableOutput.Tags)
 	}
 
 	return output, nil

--- a/pkg/aws/routetables/client_list.go
+++ b/pkg/aws/routetables/client_list.go
@@ -75,6 +75,7 @@ func (c *client) listWithFilter(ctx context.Context, roleArn, region, filterName
 	output = ListRouteTablesOutput{}
 	for _, ec2RouteTable := range ec2Output.RouteTables {
 		if ec2RouteTable.RouteTableId == nil || *ec2RouteTable.RouteTableId == "" {
+			logger.Info("Skipping route table without ID set")
 			continue
 		}
 
@@ -84,8 +85,12 @@ func (c *client) listWithFilter(ctx context.Context, roleArn, region, filterName
 		}
 
 		for _, ec2RouteTableAssociation := range ec2RouteTable.Associations {
-			if ec2RouteTableAssociation.RouteTableAssociationId == nil ||
-				ec2RouteTableAssociation.SubnetId == nil {
+			if ec2RouteTableAssociation.RouteTableAssociationId == nil {
+				logger.Info("Skipping adding route table association to output when listing (association ID not set)")
+				continue
+			}
+			if ec2RouteTableAssociation.SubnetId == nil {
+				logger.Info("Skipping adding route table association to output when listing route tables (subnet ID not set)", "route-table-id", *ec2RouteTable.RouteTableId, "association-id", *ec2RouteTableAssociation.RouteTableAssociationId)
 				continue
 			}
 

--- a/pkg/aws/routetables/client_list.go
+++ b/pkg/aws/routetables/client_list.go
@@ -32,7 +32,7 @@ func (c *client) List(ctx context.Context, input ListRouteTablesInput) (output L
 	logger.Info("Started listing route tables")
 	defer func() {
 		if err == nil {
-			logger.Info("Finished listing route tables")
+			logger.Info("Finished listing route tables", "count", len(output))
 		} else {
 			logger.Error(err, "Failed to list route tables")
 		}
@@ -73,7 +73,7 @@ func (c *client) listWithFilter(ctx context.Context, roleArn, region, filterName
 
 	output = make(ListRouteTablesOutput, len(ec2Output.RouteTables))
 	for _, ec2RouteTable := range ec2Output.RouteTables {
-		if ec2RouteTable.RouteTableId == nil {
+		if ec2RouteTable.RouteTableId == nil || *ec2RouteTable.RouteTableId == "" {
 			continue
 		}
 

--- a/pkg/aws/subnets/types.go
+++ b/pkg/aws/subnets/types.go
@@ -1,5 +1,9 @@
 package subnets
 
+import (
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
 type AssociationStateCode string
 
 // Enum values for RouteTableAssociationStateCode
@@ -15,4 +19,12 @@ const (
 type RouteTableAssociation struct {
 	RouteTableId         string
 	AssociationStateCode AssociationStateCode
+}
+
+func getAssociationStateCode(ec2AssociationState *ec2Types.RouteTableAssociationState) AssociationStateCode {
+	if ec2AssociationState != nil {
+		return AssociationStateCode(ec2AssociationState.State)
+	} else {
+		return AssociationStateCodeUnknown
+	}
 }

--- a/pkg/aws/vpc/client.go
+++ b/pkg/aws/vpc/client.go
@@ -3,6 +3,7 @@ package vpc
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/giantswarm/microerror"
@@ -42,6 +43,94 @@ func NewClient(ec2Client *ec2.Client, assumeRoleClient assumerole.Client) (Clien
 type client struct {
 	ec2Client        *ec2.Client
 	assumeRoleClient assumerole.Client
+}
+
+type attributes struct {
+	EnableDnsHostnames bool
+	EnableDnsSupport   bool
+}
+
+func (c *client) getAttributes(ctx context.Context, roleArn, region, vpcId string) (attributes, error) {
+	result := attributes{}
+
+	// get "enableDnsHostnames" attribute
+	ec2Input := ec2.DescribeVpcAttributeInput{
+		VpcId:     aws.String(vpcId),
+		Attribute: ec2Types.VpcAttributeNameEnableDnsHostnames,
+	}
+	ec2Output, err := c.ec2Client.DescribeVpcAttribute(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(roleArn, region))
+	if err != nil {
+		return result, microerror.Mask(err)
+	}
+
+	if ec2Output.EnableDnsHostnames != nil {
+		result.EnableDnsHostnames = aws.ToBool(ec2Output.EnableDnsHostnames.Value)
+	}
+
+	// get "enableDnsSupport" attribute
+	ec2Input = ec2.DescribeVpcAttributeInput{
+		VpcId:     aws.String(vpcId),
+		Attribute: ec2Types.VpcAttributeNameEnableDnsSupport,
+	}
+	ec2Output, err = c.ec2Client.DescribeVpcAttribute(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(roleArn, region))
+	if err != nil {
+		return result, microerror.Mask(err)
+	}
+
+	if ec2Output.EnableDnsSupport != nil {
+		result.EnableDnsSupport = aws.ToBool(ec2Output.EnableDnsSupport.Value)
+	}
+
+	return result, nil
+}
+
+func (c *client) updateAttribute(ctx context.Context, roleArn, region, vpcId string, attributeName ec2Types.VpcAttributeName, newValue bool) error {
+	ec2Input := ec2.ModifyVpcAttributeInput{
+		VpcId: aws.String(vpcId),
+	}
+	switch attributeName {
+	case ec2Types.VpcAttributeNameEnableDnsHostnames:
+		ec2Input.EnableDnsHostnames = &ec2Types.AttributeBooleanValue{
+			Value: aws.Bool(newValue),
+		}
+	case ec2Types.VpcAttributeNameEnableDnsSupport:
+		ec2Input.EnableDnsSupport = &ec2Types.AttributeBooleanValue{
+			Value: aws.Bool(newValue),
+		}
+	default:
+		return microerror.Maskf(errors.UnknownVpcAttributeError, "Trying to update unknown VPC attribute %q", attributeName)
+	}
+	_, err := c.ec2Client.ModifyVpcAttribute(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(roleArn, region))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (c *client) ensureAttributes(ctx context.Context, roleArn, region, vpcId string, wanted attributes) error {
+	current, err := c.getAttributes(ctx, roleArn, region, vpcId)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// ensure "enableDnsSupport" attribute has wanted value
+	if current.EnableDnsSupport != wanted.EnableDnsSupport {
+		err = c.updateAttribute(ctx, roleArn, region, vpcId, ec2Types.VpcAttributeNameEnableDnsSupport, wanted.EnableDnsSupport)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	// ensure "enableDnsHostnames" attribute has wanted value
+	if current.EnableDnsHostnames != wanted.EnableDnsHostnames {
+		err = c.updateAttribute(ctx, roleArn, region, vpcId, ec2Types.VpcAttributeNameEnableDnsHostnames, wanted.EnableDnsHostnames)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	return nil
 }
 
 // TagsToMap converts EC2 tags to map[string]string.

--- a/pkg/aws/vpc/reconciler_normal.go
+++ b/pkg/aws/vpc/reconciler_normal.go
@@ -67,10 +67,12 @@ func (s *reconciler) Reconcile(ctx context.Context, spec Spec) (Status, error) {
 	// Create new VPC
 	//
 	createVpcInput := CreateVpcInput{
-		RoleARN:   spec.RoleARN,
-		Region:    spec.Region,
-		CidrBlock: spec.CidrBlock,
-		Tags:      s.getVpcTags(spec),
+		RoleARN:            spec.RoleARN,
+		Region:             spec.Region,
+		CidrBlock:          spec.CidrBlock,
+		Tags:               s.getVpcTags(spec),
+		EnableDnsHostnames: true,
+		EnableDnsSupport:   true,
 	}
 	createVpcOutput, err := s.client.Create(ctx, createVpcInput)
 	if err != nil {

--- a/pkg/aws/vpcendpoint/client.go
+++ b/pkg/aws/vpcendpoint/client.go
@@ -1,0 +1,56 @@
+package vpcendpoint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-vpc-operator/pkg/aws/assumerole"
+	"github.com/giantswarm/aws-vpc-operator/pkg/aws/tags"
+	"github.com/giantswarm/aws-vpc-operator/pkg/errors"
+)
+
+const (
+	StateAvailable = string(ec2Types.StateAvailable)
+	StateDeleting  = string(ec2Types.StateDeleting)
+	StateDeleted   = string(ec2Types.StateDeleted)
+)
+
+type Client interface {
+	Create(ctx context.Context, input CreateVpcEndpointInput) (CreateVpcEndpointOutput, error)
+	Get(ctx context.Context, input GetVpcEndpointInput) (GetVpcEndpointOutput, error)
+	Delete(ctx context.Context, input DeleteVpcEndpointInput) error
+}
+
+func NewClient(ec2Client *ec2.Client, assumeRoleClient assumerole.Client) (Client, error) {
+	if ec2Client == nil {
+		return nil, microerror.Maskf(errors.InvalidConfigError, "ec2Client must not be empty")
+	}
+	if assumeRoleClient == nil {
+		return nil, microerror.Maskf(errors.InvalidConfigError, "assumeRoleClient must not be empty")
+	}
+
+	tagsClient, err := tags.NewClient(ec2Client, assumeRoleClient)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return &client{
+		ec2Client:        ec2Client,
+		assumeRoleClient: assumeRoleClient,
+		tagsClient:       tagsClient,
+	}, nil
+}
+
+type client struct {
+	ec2Client        *ec2.Client
+	tagsClient       tags.Client
+	assumeRoleClient assumerole.Client
+}
+
+func secretsManagerServiceName(region string) string {
+	return fmt.Sprintf("com.amazonaws.%s.secretsmanager", region)
+}

--- a/pkg/aws/vpcendpoint/client_create.go
+++ b/pkg/aws/vpcendpoint/client_create.go
@@ -32,7 +32,7 @@ func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (outp
 	logger.Info("Started creating VPC endpoint")
 	defer func() {
 		if err == nil {
-			logger.Info("Finished creating VPC endpoint")
+			logger.Info("Finished creating VPC endpoint", "vpc-endpoint-id", output.VpcEndpointId, "vpc-endpoint-state", output.VpcEndpointState)
 		} else {
 			logger.Error(err, "Failed to create VPC endpoint")
 		}

--- a/pkg/aws/vpcendpoint/client_create.go
+++ b/pkg/aws/vpcendpoint/client_create.go
@@ -1,0 +1,77 @@
+package vpcendpoint
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/giantswarm/aws-vpc-operator/pkg/aws/tags"
+	"github.com/giantswarm/aws-vpc-operator/pkg/errors"
+)
+
+type CreateVpcEndpointInput struct {
+	RoleARN          string
+	Region           string
+	VpcId            string
+	SubnetIds        []string
+	SecurityGroupIds []string
+	Tags             map[string]string
+}
+
+type CreateVpcEndpointOutput struct {
+	VpcEndpointId    string
+	VpcEndpointState string
+}
+
+func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (output CreateVpcEndpointOutput, err error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Started creating VPC endpoint")
+	defer func() {
+		if err == nil {
+			logger.Info("Finished creating VPC endpoint")
+		} else {
+			logger.Error(err, "Failed to create VPC endpoint")
+		}
+	}()
+
+	if input.RoleARN == "" {
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.RoleARN must not be empty", input)
+	}
+	if input.Region == "" {
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.Region must not be empty", input)
+	}
+	if input.VpcId == "" {
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
+	}
+
+	ec2Input := ec2.CreateVpcEndpointInput{
+		VpcId:       aws.String(input.VpcId),
+		ServiceName: aws.String(secretsManagerServiceName(input.Region)),
+		DnsOptions: &ec2Types.DnsOptionsSpecification{
+			DnsRecordIpType: ec2Types.DnsRecordIpTypeIpv4,
+		},
+		IpAddressType:     ec2Types.IpAddressTypeIpv4,
+		PrivateDnsEnabled: aws.Bool(true),
+		SecurityGroupIds:  input.SecurityGroupIds,
+		SubnetIds:         input.SubnetIds,
+		TagSpecifications: []ec2Types.TagSpecification{
+			tags.BuildParamsToTagSpecification(ec2Types.ResourceTypeVpcEndpoint, input.Tags),
+		},
+		VpcEndpointType: ec2Types.VpcEndpointTypeInterface,
+	}
+	ec2Output, err := c.ec2Client.CreateVpcEndpoint(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(input.RoleARN, input.Region))
+	if err != nil {
+		return CreateVpcEndpointOutput{}, microerror.Mask(err)
+	}
+
+	output = CreateVpcEndpointOutput{
+		VpcEndpointId:    *ec2Output.VpcEndpoint.VpcEndpointId,
+		VpcEndpointState: string(ec2Output.VpcEndpoint.State),
+	}
+
+	return output, err
+}

--- a/pkg/aws/vpcendpoint/client_delete.go
+++ b/pkg/aws/vpcendpoint/client_delete.go
@@ -1,0 +1,62 @@
+package vpcendpoint
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/giantswarm/aws-vpc-operator/pkg/errors"
+)
+
+type DeleteVpcEndpointInput struct {
+	RoleARN string
+	Region  string
+	VpcId   string
+}
+
+func (c *client) Delete(ctx context.Context, input DeleteVpcEndpointInput) (err error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Started deleting VPC endpoint")
+	defer func() {
+		if err == nil {
+			logger.Info("Finished deleting VPC endpoint")
+		} else {
+			logger.Error(err, "Failed to delete VPC endpoint")
+		}
+	}()
+
+	if input.RoleARN == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.RoleARN must not be empty", input)
+	}
+	if input.Region == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.Region must not be empty", input)
+	}
+	if input.VpcId == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
+	}
+
+	getInput := GetVpcEndpointInput(input)
+	vpcEndpoint, err := c.Get(ctx, getInput)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if vpcEndpoint.VpcEndpointState == StateDeleted {
+		return microerror.Maskf(errors.ResourceAlreadyDeletedError, "VPC endpoint is already deleted")
+	}
+	if vpcEndpoint.VpcEndpointState == StateDeleting {
+		return microerror.Maskf(errors.ResourceDeletionInProgressError, "VPC endpoint deletion is already in progress")
+	}
+
+	ec2Input := ec2.DeleteVpcEndpointsInput{
+		VpcEndpointIds: []string{vpcEndpoint.VpcEndpointId},
+	}
+	_, err = c.ec2Client.DeleteVpcEndpoints(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(input.RoleARN, input.Region))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return err
+}

--- a/pkg/aws/vpcendpoint/client_delete.go
+++ b/pkg/aws/vpcendpoint/client_delete.go
@@ -18,7 +18,7 @@ type DeleteVpcEndpointInput struct {
 
 func (c *client) Delete(ctx context.Context, input DeleteVpcEndpointInput) (err error) {
 	logger := log.FromContext(ctx)
-	logger.Info("Started deleting VPC endpoint")
+	logger.Info("Started deleting VPC endpoint", "vpc-id", input.VpcId)
 	defer func() {
 		if err == nil {
 			logger.Info("Finished deleting VPC endpoint")
@@ -44,12 +44,17 @@ func (c *client) Delete(ctx context.Context, input DeleteVpcEndpointInput) (err 
 	}
 
 	if vpcEndpoint.VpcEndpointState == StateDeleted {
-		return microerror.Maskf(errors.ResourceAlreadyDeletedError, "VPC endpoint is already deleted")
+		message := "VPC endpoint is already deleted"
+		logger.Info(message, "vpc-endpoint-id", vpcEndpoint.VpcEndpointId)
+		return microerror.Maskf(errors.ResourceAlreadyDeletedError, message)
 	}
 	if vpcEndpoint.VpcEndpointState == StateDeleting {
-		return microerror.Maskf(errors.ResourceDeletionInProgressError, "VPC endpoint deletion is already in progress")
+		message := "VPC endpoint deletion is already in progress"
+		logger.Info(message, "vpc-endpoint-id", vpcEndpoint.VpcEndpointId)
+		return microerror.Maskf(errors.ResourceDeletionInProgressError, message)
 	}
 
+	logger.Info("Found VPC endpoint to delete", "vpc-endpoint-id", vpcEndpoint.VpcEndpointId)
 	ec2Input := ec2.DeleteVpcEndpointsInput{
 		VpcEndpointIds: []string{vpcEndpoint.VpcEndpointId},
 	}

--- a/pkg/aws/vpcendpoint/client_get.go
+++ b/pkg/aws/vpcendpoint/client_get.go
@@ -1,0 +1,78 @@
+package vpcendpoint
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/giantswarm/aws-vpc-operator/pkg/errors"
+)
+
+type GetVpcEndpointInput struct {
+	RoleARN string
+	Region  string
+	VpcId   string
+}
+
+type GetVpcEndpointOutput struct {
+	VpcEndpointId    string
+	VpcEndpointState string
+}
+
+func (c *client) Get(ctx context.Context, input GetVpcEndpointInput) (output GetVpcEndpointOutput, err error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Started getting VPC endpoint")
+	defer func() {
+		if err == nil {
+			logger.Info("Finished getting VPC endpoint")
+		} else {
+			logger.Error(err, "Failed to get VPC endpoint")
+		}
+	}()
+
+	if input.RoleARN == "" {
+		return GetVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.RoleARN must not be empty", input)
+	}
+	if input.Region == "" {
+		return GetVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.Region must not be empty", input)
+	}
+	if input.VpcId == "" {
+		return GetVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
+	}
+
+	ec2Input := ec2.DescribeVpcEndpointsInput{
+		Filters: []ec2Types.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []string{input.VpcId},
+			},
+			{
+				Name:   aws.String("service-name"),
+				Values: []string{secretsManagerServiceName(input.Region)},
+			},
+			{
+				Name:   aws.String("vpc-endpoint-type"),
+				Values: []string{string(ec2Types.VpcEndpointTypeInterface)},
+			},
+		},
+	}
+	ec2Output, err := c.ec2Client.DescribeVpcEndpoints(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(input.RoleARN, input.Region))
+	if err != nil {
+		return GetVpcEndpointOutput{}, microerror.Mask(err)
+	}
+
+	if len(ec2Output.VpcEndpoints) == 0 {
+		return GetVpcEndpointOutput{}, microerror.Maskf(errors.VpcEndpointNotFoundError, "VPC Secrets Manager %s endpoint for VPC %s", ec2Types.VpcEndpointTypeInterface, input.VpcId)
+	}
+
+	output = GetVpcEndpointOutput{
+		VpcEndpointId:    *ec2Output.VpcEndpoints[0].VpcEndpointId,
+		VpcEndpointState: string(ec2Output.VpcEndpoints[0].State),
+	}
+
+	return output, err
+}

--- a/pkg/aws/vpcendpoint/client_get.go
+++ b/pkg/aws/vpcendpoint/client_get.go
@@ -28,7 +28,7 @@ func (c *client) Get(ctx context.Context, input GetVpcEndpointInput) (output Get
 	logger.Info("Started getting VPC endpoint")
 	defer func() {
 		if err == nil {
-			logger.Info("Finished getting VPC endpoint")
+			logger.Info("Finished getting VPC endpoint", "vpc-endpoint-id", output.VpcEndpointId, "vpc-endpoint-state", output.VpcEndpointState)
 		} else {
 			logger.Error(err, "Failed to get VPC endpoint")
 		}

--- a/pkg/aws/vpcendpoint/reconciler.go
+++ b/pkg/aws/vpcendpoint/reconciler.go
@@ -1,0 +1,29 @@
+package vpcendpoint
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/aws-vpc-operator/pkg/aws"
+	"github.com/giantswarm/aws-vpc-operator/pkg/errors"
+)
+
+type Reconciler interface {
+	Reconcile(ctx context.Context, request aws.ReconcileRequest[Spec]) (aws.ReconcileResult[Status], error)
+	ReconcileDelete(ctx context.Context, request aws.ReconcileRequest[aws.DeletedCloudResourceSpec]) error
+}
+
+func NewReconciler(client Client) (Reconciler, error) {
+	if client == nil {
+		return nil, microerror.Maskf(errors.InvalidConfigError, "client must not be empty")
+	}
+
+	return &reconciler{
+		client: client,
+	}, nil
+}
+
+type reconciler struct {
+	client Client
+}

--- a/pkg/aws/vpcendpoint/reconciler_delete.go
+++ b/pkg/aws/vpcendpoint/reconciler_delete.go
@@ -1,0 +1,57 @@
+package vpcendpoint
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/giantswarm/aws-vpc-operator/pkg/aws"
+	"github.com/giantswarm/aws-vpc-operator/pkg/errors"
+)
+
+func (r *reconciler) ReconcileDelete(ctx context.Context, request aws.ReconcileRequest[aws.DeletedCloudResourceSpec]) (err error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Started reconciling VPC endpoint deletion")
+	defer func() {
+		if err == nil {
+			logger.Info("Finished reconciling VPC endpoint deletion")
+		} else {
+			logger.Error(err, "Failed to reconcile VPC endpoint deletion")
+		}
+	}()
+
+	if request.ClusterName == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.ClusterName must not be empty", request)
+	}
+	if request.RoleARN == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.RoleARN must not be empty", request)
+	}
+	if request.Region == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.Region must not be empty", request)
+	}
+	if request.Spec.Id == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.Spec.Id must not be empty", request)
+	}
+
+	input := DeleteVpcEndpointInput{
+		RoleARN: request.RoleARN,
+		Region:  request.Region,
+		VpcId:   request.Spec.Id,
+	}
+	err = r.client.Delete(ctx, input)
+	if errors.IsVpcEndpointNotFound(err) {
+		logger.Info("Nothing to delete, VPC endpoint not found")
+		return nil
+	} else if errors.IsResourceAlreadyDeleted(err) {
+		logger.Info("Nothing to delete, VPC endpoint already deleted")
+		return nil
+	} else if errors.IsResourceDeletionInProgress(err) {
+		logger.Info("VPC endpoint deletion is already in progress")
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/pkg/aws/vpcendpoint/reconciler_normal.go
+++ b/pkg/aws/vpcendpoint/reconciler_normal.go
@@ -1,0 +1,84 @@
+package vpcendpoint
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/giantswarm/aws-vpc-operator/pkg/aws"
+	"github.com/giantswarm/aws-vpc-operator/pkg/errors"
+)
+
+type Spec struct {
+	VpcId            string
+	SubnetIds        []string
+	SecurityGroupIds []string
+	AdditionalTags   map[string]string
+}
+
+type Status struct {
+	VpcEndpointId    string
+	VpcEndpointState string
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, request aws.ReconcileRequest[Spec]) (result aws.ReconcileResult[Status], err error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Started reconciling VPC endpoint")
+	defer func() {
+		if err == nil {
+			logger.Info("Finished reconciling VPC endpoint")
+		} else {
+			logger.Error(err, "Failed to reconcile VPC endpoint")
+		}
+	}()
+
+	if request.ClusterName == "" {
+		return aws.ReconcileResult[Status]{}, microerror.Maskf(errors.InvalidConfigError, "ClusterName must not be empty")
+	}
+	if request.RoleARN == "" {
+		return aws.ReconcileResult[Status]{}, microerror.Maskf(errors.InvalidConfigError, "RoleARN must not be empty")
+	}
+	if request.Region == "" {
+		return aws.ReconcileResult[Status]{}, microerror.Maskf(errors.InvalidConfigError, "Region must not be empty")
+	}
+	if request.Spec.VpcId == "" {
+		return aws.ReconcileResult[Status]{}, microerror.Maskf(errors.InvalidConfigError, "VpcId must not be empty")
+	}
+
+	result = aws.ReconcileResult[Status]{
+		Status: Status{},
+	}
+
+	// Get existing VPC endpoint
+	getInput := GetVpcEndpointInput{
+		RoleARN: request.RoleARN,
+		Region:  request.Region,
+		VpcId:   request.Spec.VpcId,
+	}
+	getOutput, err := r.client.Get(ctx, getInput)
+	if errors.IsVpcEndpointNotFound(err) {
+		// VPC endpoint not found, so we create one
+		createInput := CreateVpcEndpointInput{
+			RoleARN:          request.RoleARN,
+			Region:           request.Region,
+			VpcId:            request.Spec.VpcId,
+			SubnetIds:        request.Spec.SubnetIds,
+			SecurityGroupIds: request.Spec.SecurityGroupIds,
+			Tags:             nil, // TODO set tags
+		}
+		createOutput, err := r.client.Create(ctx, createInput)
+		if err != nil {
+			return aws.ReconcileResult[Status]{}, microerror.Mask(err)
+		}
+
+		result.Status = Status(createOutput)
+		return result, nil
+	} else if err != nil {
+		return aws.ReconcileResult[Status]{}, microerror.Mask(err)
+	}
+
+	// TODO update existing VPC endpoint (e.g. update tags)
+	result.Status = Status(getOutput)
+	return result, nil
+}

--- a/pkg/errors/aws.go
+++ b/pkg/errors/aws.go
@@ -66,3 +66,30 @@ var UnknownVpcAttributeError = &microerror.Error{
 func IsUnknownVpcAttribute(err error) bool {
 	return microerror.Cause(err) == UnknownVpcAttributeError
 }
+
+var VpcEndpointNotFoundError = &microerror.Error{
+	Kind: "VpcEndpointNotFoundError",
+}
+
+// IsVpcEndpointNotFound asserts VpcEndpointNotFoundError.
+func IsVpcEndpointNotFound(err error) bool {
+	return microerror.Cause(err) == VpcEndpointNotFoundError
+}
+
+var ResourceDeletionInProgressError = &microerror.Error{
+	Kind: "ResourceDeletionInProgressError",
+}
+
+// IsResourceDeletionInProgress asserts ResourceDeletionInProgressError.
+func IsResourceDeletionInProgress(err error) bool {
+	return microerror.Cause(err) == ResourceDeletionInProgressError
+}
+
+var ResourceAlreadyDeletedError = &microerror.Error{
+	Kind: "ResourceAlreadyDeletedError",
+}
+
+// IsResourceAlreadyDeleted asserts ResourceAlreadyDeletedError.
+func IsResourceAlreadyDeleted(err error) bool {
+	return microerror.Cause(err) == ResourceAlreadyDeletedError
+}

--- a/pkg/errors/aws.go
+++ b/pkg/errors/aws.go
@@ -57,3 +57,12 @@ var RouteTableNotFoundError = &microerror.Error{
 func IsRouteTableNotFound(err error) bool {
 	return microerror.Cause(err) == RouteTableNotFoundError
 }
+
+var UnknownVpcAttributeError = &microerror.Error{
+	Kind: "UnknownVpcAttribute",
+}
+
+// IsUnknownVpcAttribute asserts UnknownVpcAttributeError.
+func IsUnknownVpcAttribute(err error) bool {
+	return microerror.Cause(err) == UnknownVpcAttributeError
+}


### PR DESCRIPTION
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how aws-vpc-operator can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works
- [ ] aws-vpc-operator manages only VPCs that are not managed by CAPA

#### Other testing

Description of features to additionally test for aws-vpc-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] AWS VPC works after aws-vpc-operator upgrade

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
