### PR TITLE
Ensure assume role when getting endpoints subnets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure the cluster role is assumed when getting endpoints subnets
+
 ## [0.2.0] - 2023-01-13
 
 ### Fixed

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -538,7 +538,11 @@ func (r *AWSClusterReconciler) reconcileNormal(ctx context.Context, logger logr.
 			},
 		}
 
-		subnetIDs, err := r.subnetsClient.GetEndpointSubnets(ctx, awsCluster.Name)
+		subnetIDs, err := r.subnetsClient.GetEndpointSubnets(ctx, subnets.GetEndpointSubnetsInput{
+			ClusterName: awsCluster.Name,
+			RoleARN:     roleArn,
+			Region:      awsCluster.Spec.Region,
+		})
 		if err != nil {
 			log.Error(err, "Failed to lookup subnets")
 			capiconditions.MarkFalse(awsCluster, VpcEndpointReady, SubnetLookupFailed, capi.ConditionSeverityWarning, "Failed to lookup subnets to use for VPC Endpoints")

--- a/pkg/aws/subnets/client.go
+++ b/pkg/aws/subnets/client.go
@@ -17,7 +17,7 @@ type Client interface {
 	Update(ctx context.Context, input UpdateSubnetInput) (UpdateSubnetOutput, error)
 	Get(ctx context.Context, input GetSubnetsInput) (GetSubnetsOutput, error)
 	Delete(ctx context.Context, input DeleteSubnetsInput) error
-	GetEndpointSubnets(ctx context.Context, clusterName string) ([]string, error)
+	GetEndpointSubnets(ctx context.Context, input GetEndpointSubnetsInput) ([]string, error)
 }
 
 func NewClient(ec2Client *ec2.Client, assumeRoleClient assumerole.Client) (Client, error) {


### PR DESCRIPTION
Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- assumes the role of the WC when getting the subnets for VPC endpoints

### Testing

Description on how aws-vpc-operator can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works
- [ ] aws-vpc-operator manages only VPCs that are not managed by CAPA

#### Other testing

Description of features to additionally test for aws-vpc-operator installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] AWS VPC works after aws-vpc-operator upgrade

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
