### PR TITLE
make endpoint creation configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't create VPC Endpoints if VPC Endpoint annotation is set to `UserManaged`
+
 ## [0.3.0] - 2023-01-30
 
 ### Changed

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -745,10 +745,7 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, logger logr.
 }
 
 func shouldReconcileVpcEndpoint(annotations map[string]string) bool {
-	if annotations[VpcEndpointMode] != "UserManaged" {
-		return true
-	}
-	return false
+	return annotations[VpcEndpointMode] != "UserManaged"
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -57,6 +57,8 @@ const (
 	VpcEndpointReady              capi.ConditionType = "VpcEndpointReady"
 	ClusterSecurityGroupsNotReady string             = "ClusterSecurityGroupsNotReady"
 	SubnetLookupFailed            string             = "SubnetLookupFailed"
+
+	VpcEndpointMode string = "aws.giantswarm.io/vpc-endpoint-mode"
 )
 
 // AWSClusterReconciler reconciles a AWSCluster object
@@ -537,47 +539,48 @@ func (r *AWSClusterReconciler) reconcileNormal(ctx context.Context, logger logr.
 				AdditionalTags: awsCluster.Spec.AdditionalTags,
 			},
 		}
-
-		subnetIDs, err := r.subnetsClient.GetEndpointSubnets(ctx, subnets.GetEndpointSubnetsInput{
-			ClusterName: awsCluster.Name,
-			RoleARN:     roleArn,
-			Region:      awsCluster.Spec.Region,
-		})
-		if err != nil {
-			log.Error(err, "Failed to lookup subnets")
-			capiconditions.MarkFalse(awsCluster, VpcEndpointReady, SubnetLookupFailed, capi.ConditionSeverityWarning, "Failed to lookup subnets to use for VPC Endpoints")
-			return ctrl.Result{}, err
-		}
-		// If no specific subnets found we'll fallback to picking any from the cluster
-		if len(subnetIDs) == 0 {
-			log.Info("No specific subnets found for VPC endpoints, falling back to using subnets from AWSCluster spec")
-			selectedAZs := map[string]bool{}
-			for _, subnet := range awsCluster.Spec.NetworkSpec.Subnets {
-				if selectedAZs[subnet.AvailabilityZone] {
-					// VPC endpoints can only have a single subnet per AZ so we'll skip any additional
-					continue
-				}
-				subnetIDs = append(reconcileRequest.Spec.SubnetIds, subnet.ID)
-				selectedAZs[subnet.AvailabilityZone] = true
+		if shouldReconcileVpcEndpoint(awsCluster.Annotations) {
+			subnetIDs, err := r.subnetsClient.GetEndpointSubnets(ctx, subnets.GetEndpointSubnetsInput{
+				ClusterName: awsCluster.Name,
+				RoleARN:     roleArn,
+				Region:      awsCluster.Spec.Region,
+			})
+			if err != nil {
+				log.Error(err, "Failed to lookup subnets")
+				capiconditions.MarkFalse(awsCluster, VpcEndpointReady, SubnetLookupFailed, capi.ConditionSeverityWarning, "Failed to lookup subnets to use for VPC Endpoints")
+				return ctrl.Result{}, err
 			}
-		}
-		reconcileRequest.Spec.SubnetIds = subnetIDs
+			// If no specific subnets found we'll fallback to picking any from the cluster
+			if len(subnetIDs) == 0 {
+				log.Info("No specific subnets found for VPC endpoints, falling back to using subnets from AWSCluster spec")
+				selectedAZs := map[string]bool{}
+				for _, subnet := range awsCluster.Spec.NetworkSpec.Subnets {
+					if selectedAZs[subnet.AvailabilityZone] {
+						// VPC endpoints can only have a single subnet per AZ so we'll skip any additional
+						continue
+					}
+					subnetIDs = append(reconcileRequest.Spec.SubnetIds, subnet.ID)
+					selectedAZs[subnet.AvailabilityZone] = true
+				}
+			}
+			reconcileRequest.Spec.SubnetIds = subnetIDs
 
-		for _, securityGroup := range awsCluster.Status.Network.SecurityGroups {
-			reconcileRequest.Spec.SecurityGroupIds = append(reconcileRequest.Spec.SecurityGroupIds, securityGroup.ID)
-		}
-		result, err := r.vpcEndpointReconciler.Reconcile(ctx, reconcileRequest)
-		if err != nil {
-			capiconditions.MarkFalse(awsCluster, VpcEndpointReady, "ReconciliationError", capi.ConditionSeverityError, "An error occurred during reconciliation, check logs")
-			return ctrl.Result{}, microerror.Mask(err)
-		}
+			for _, securityGroup := range awsCluster.Status.Network.SecurityGroups {
+				reconcileRequest.Spec.SecurityGroupIds = append(reconcileRequest.Spec.SecurityGroupIds, securityGroup.ID)
+			}
+			result, err := r.vpcEndpointReconciler.Reconcile(ctx, reconcileRequest)
+			if err != nil {
+				capiconditions.MarkFalse(awsCluster, VpcEndpointReady, "ReconciliationError", capi.ConditionSeverityError, "An error occurred during reconciliation, check logs")
+				return ctrl.Result{}, microerror.Mask(err)
+			}
 
-		if strings.EqualFold(result.Status.VpcEndpointState, vpcendpoint.StateAvailable) {
-			capiconditions.MarkTrue(awsCluster, VpcEndpointReady)
-		} else {
-			reason := fmt.Sprintf("VpcEndpointState%s", result.Status.VpcEndpointState)
-			capiconditions.MarkFalse(awsCluster, VpcEndpointReady, reason, capi.ConditionSeverityWarning, "VPC endpoint is not available")
-			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+			if strings.EqualFold(result.Status.VpcEndpointState, vpcendpoint.StateAvailable) {
+				capiconditions.MarkTrue(awsCluster, VpcEndpointReady)
+			} else {
+				reason := fmt.Sprintf("VpcEndpointState%s", result.Status.VpcEndpointState)
+				capiconditions.MarkFalse(awsCluster, VpcEndpointReady, reason, capi.ConditionSeverityWarning, "VPC endpoint is not available")
+				return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+			}
 		}
 	}
 
@@ -589,28 +592,30 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, logger logr.
 	// Delete VPC endpoint. We delete VPC endpoint first, regardless of what CAPA
 	// deleted (if anything) until now.
 	//
-	if isDeleted(awsCluster, VpcEndpointReady) {
-		logger.Info("VPC endpoint is already deleted")
-	} else {
-		vpcId := awsCluster.Spec.NetworkSpec.VPC.ID
-		logger.Info("Deleting VPC endpoint", "vpc-id", vpcId)
-		vpcEndpointDeleteRequest := aws.ReconcileRequest[aws.DeletedCloudResourceSpec]{
-			Resource:    awsCluster,
-			ClusterName: awsCluster.Name,
-			CloudResourceRequest: aws.CloudResourceRequest[aws.DeletedCloudResourceSpec]{
-				RoleARN: roleArn,
-				Region:  awsCluster.Spec.Region,
-				Spec: aws.DeletedCloudResourceSpec{
-					Id: awsCluster.Spec.NetworkSpec.VPC.ID,
+	if shouldReconcileVpcEndpoint(awsCluster.Annotations) {
+		if isDeleted(awsCluster, VpcEndpointReady) {
+			logger.Info("VPC endpoint is already deleted")
+		} else {
+			vpcId := awsCluster.Spec.NetworkSpec.VPC.ID
+			logger.Info("Deleting VPC endpoint", "vpc-id", vpcId)
+			vpcEndpointDeleteRequest := aws.ReconcileRequest[aws.DeletedCloudResourceSpec]{
+				Resource:    awsCluster,
+				ClusterName: awsCluster.Name,
+				CloudResourceRequest: aws.CloudResourceRequest[aws.DeletedCloudResourceSpec]{
+					RoleARN: roleArn,
+					Region:  awsCluster.Spec.Region,
+					Spec: aws.DeletedCloudResourceSpec{
+						Id: awsCluster.Spec.NetworkSpec.VPC.ID,
+					},
 				},
-			},
+			}
+			err = r.vpcEndpointReconciler.ReconcileDelete(ctx, vpcEndpointDeleteRequest)
+			if err != nil {
+				return ctrl.Result{}, microerror.Mask(err)
+			}
+			conditions.MarkFalse(awsCluster, VpcEndpointReady, capi.DeletedReason, capi.ConditionSeverityInfo, "VPC endpoint has been deleted")
+			logger.Info("Deleted VPC endpoint", "vpc-id", vpcId)
 		}
-		err = r.vpcEndpointReconciler.ReconcileDelete(ctx, vpcEndpointDeleteRequest)
-		if err != nil {
-			return ctrl.Result{}, microerror.Mask(err)
-		}
-		conditions.MarkFalse(awsCluster, VpcEndpointReady, capi.DeletedReason, capi.ConditionSeverityInfo, "VPC endpoint has been deleted")
-		logger.Info("Deleted VPC endpoint", "vpc-id", vpcId)
 	}
 
 	//
@@ -737,6 +742,13 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, logger logr.
 	// Cluster is deleted so remove the finalizer.
 	controllerutil.RemoveFinalizer(awsCluster, AwsVpcOperatorFinalizer)
 	return ctrl.Result{}, nil
+}
+
+func shouldReconcileVpcEndpoint(annotations map[string]string) bool {
+	if annotations[VpcEndpointMode] != "UserManaged" {
+		return true
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.60.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19
 	github.com/aws/smithy-go v1.13.3
-	github.com/giantswarm/k8smetadata v0.15.0
+	github.com/giantswarm/k8smetadata v0.20.0
 	github.com/giantswarm/microerror v0.4.0
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.1.6

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwV
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/giantswarm/k8smetadata v0.15.0 h1:bAJSwXpGZvfqVyL068GRc+dO3NLPL/Ci/3F/mhSjh0I=
-github.com/giantswarm/k8smetadata v0.15.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
+github.com/giantswarm/k8smetadata v0.20.0 h1:wvKD2SkFsNxQkbnvRbq/e2DHVqoQVeNxehGOmcIdTL8=
+github.com/giantswarm/k8smetadata v0.20.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/microerror v0.4.0 h1:QeU+UZL0rRlVXKqYOHMxS0L7g8UD+dn84NT7myWVh4U=
 github.com/giantswarm/microerror v0.4.0/go.mod h1:Ju1YdC6TX/8witv7fIlkgiRr5FQUNyq3f4TX2QYnO7c=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/pkg/aws/vpcendpoint/reconciler_delete.go
+++ b/pkg/aws/vpcendpoint/reconciler_delete.go
@@ -21,6 +21,10 @@ func (r *reconciler) ReconcileDelete(ctx context.Context, request aws.ReconcileR
 		}
 	}()
 
+	if !shouldReconcileVpcEndpoint(request.Resource.GetAnnotations()) {
+		return nil
+	}
+
 	if request.ClusterName == "" {
 		return microerror.Maskf(errors.InvalidConfigError, "%T.ClusterName must not be empty", request)
 	}

--- a/pkg/aws/vpcendpoint/reconciler_normal.go
+++ b/pkg/aws/vpcendpoint/reconciler_normal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	capa "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
 	capaservices "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
@@ -13,10 +14,6 @@ import (
 	"github.com/giantswarm/aws-vpc-operator/pkg/aws"
 	"github.com/giantswarm/aws-vpc-operator/pkg/aws/tags"
 	"github.com/giantswarm/aws-vpc-operator/pkg/errors"
-)
-
-const (
-	VpcEndpointMode string = "aws.giantswarm.io/vpc-endpoint-mode"
 )
 
 type Spec struct {
@@ -207,5 +204,5 @@ func diff(sortedS1, sortedS2 []string) []string {
 }
 
 func shouldReconcileVpcEndpoint(annotations map[string]string) bool {
-	return annotations[VpcEndpointMode] != "UserManaged"
+	return annotations[annotation.VPCEndpointModeAnnotation] != annotation.VPCEndpointModeUserManaged
 }


### PR DESCRIPTION
This PR:

- adds  to check for vpc endpoint annotation, if it is set to UserManaged, do not reconcile

Towards https://github.com/giantswarm/roadmap/issues/1926

### Testing

If respective annotation is present with value `UserManaged`, vpc operator should not create any endpoints.

- [x] fresh install works
- [x] upgrade from previous version works
- [ ] aws-vpc-operator manages only VPCs that are not managed by CAPA

#### Other testing

Description of features to additionally test for aws-vpc-operator installations.

- [x] check reconciliation of existing resources after upgrading
- [x] AWS VPC works after aws-vpc-operator upgrade

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
