### PR TITLE
Do not generate a name if `Name` tag already given so that we can never confuse the values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Don't create VPC Endpoints if VPC Endpoint annotation is set to `UserManaged`
+- Do not generate a name if `Name` tag already given so that we can never confuse the values
 
 ## [0.3.0] - 2023-01-30
 

--- a/pkg/aws/subnets/reconciler.go
+++ b/pkg/aws/subnets/reconciler.go
@@ -67,12 +67,18 @@ func (r *reconciler) getSubnetTags(clusterName string, clusterTags map[string]st
 	}
 
 	// 4. finally, build all tags with tag builder which also sets predefined/fixed tags
+
+	// Prefer `Name` tag if given, else generate a name
 	var name strings.Builder
-	name.WriteString(clusterName)
-	name.WriteString("-subnet-")
-	name.WriteString(role)
-	name.WriteString("-")
-	name.WriteString(spec.AvailabilityZone)
+	if manualTagName, ok := spec.Tags["Name"]; ok {
+		name.WriteString(manualTagName)
+	} else {
+		name.WriteString(clusterName)
+		name.WriteString("-subnet-")
+		name.WriteString(role)
+		name.WriteString("-")
+		name.WriteString(spec.AvailabilityZone)
+	}
 
 	id := spec.SubnetId
 	if id == "" {

--- a/pkg/aws/tags/builder.go
+++ b/pkg/aws/tags/builder.go
@@ -34,6 +34,8 @@ type BuildParams struct {
 // Copied from sigs.k8s.io/cluster-api-provider-aws.
 func (p BuildParams) Build() map[string]string {
 	tags := make(map[string]string)
+
+	// Add the name tag first so that it can be overwritten by a user-provided tag in the `Additional` tags.
 	if p.Name != "" {
 		tags["Name"] = p.Name
 	}


### PR DESCRIPTION
Same change as applied to CAPA. This way, we don't have 2 distinct values for one semantic meaning, reducing chances to introduce bugs. The related issue https://github.com/giantswarm/roadmap/issues/1866 should already have been solved by https://github.com/giantswarm/aws-vpc-operator/pull/31.

Not tested, since it's a trivial change that we confirmed working in very similar CAPA code.

### Checklist

- [ ] Update changelog in CHANGELOG.md. => Code change is internal, so I didn't touch the changelog.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
