### PR TITLE
Allow required volume types in PSP to fix pod admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add the use of the runtime/default seccomp profile.
+### Added
+
+- Add the use of the runtime/default seccomp profile. Allow required volume types in PSP so that pods can still be admitted.
 
 ### Changed
 

--- a/helm/aws-vpc-operator/templates/psp.yaml
+++ b/helm/aws-vpc-operator/templates/psp.yaml
@@ -25,6 +25,11 @@ spec:
     rule: RunAsAny
   supplementalGroups:
     rule: RunAsAny
+  volumes:
+    # Used directly in deployment
+    - secret
+    # Needed for Kubernetes API access (https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+    - projected
   allowPrivilegeEscalation: false
   hostNetwork: false
   hostIPC: false


### PR DESCRIPTION
Adding the seccomp profile made pod admission fail. Explicitly list which volume types we need. Tested manually in an  existing MC.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
