### PR TITLE
add-s3-vpc-endpoint

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -2,3 +2,6 @@ sonatype-2022-6522
 
 # pkg:golang/k8s.io/apiserver@v0.25.0
 CVE-2020-8561
+
+# pkg:golang/google.golang.org/grpc@v1.47.0
+CVE-2023-32731 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add necessary values for PSS policy warnings. 
 
+### Changed
+
+-  migrate from `secretmanager` VPC endpoint to `s3` endpoint for Flatcar.
+
 ## [0.4.0] - 2023-03-15
 
 ### Changed

--- a/pkg/aws/vpcendpoint/client.go
+++ b/pkg/aws/vpcendpoint/client.go
@@ -55,7 +55,3 @@ type client struct {
 func s3ServiceName(region string) string {
 	return fmt.Sprintf("com.amazonaws.%s.s3", region)
 }
-
-func secretsManagerServiceName(region string) string {
-	return fmt.Sprintf("com.amazonaws.%s.secretsmanager", region)
-}

--- a/pkg/aws/vpcendpoint/client.go
+++ b/pkg/aws/vpcendpoint/client.go
@@ -52,6 +52,10 @@ type client struct {
 	assumeRoleClient assumerole.Client
 }
 
+func s3ServiceName(region string) string {
+	return fmt.Sprintf("com.amazonaws.%s.s3", region)
+}
+
 func secretsManagerServiceName(region string) string {
 	return fmt.Sprintf("com.amazonaws.%s.secretsmanager", region)
 }

--- a/pkg/aws/vpcendpoint/client_create.go
+++ b/pkg/aws/vpcendpoint/client_create.go
@@ -63,9 +63,7 @@ func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (outp
 		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig cannot be nil", input)
 	}
 
-	var ec2Input ec2.CreateVpcEndpointInput
-
-	ec2Input = ec2.CreateVpcEndpointInput{
+	ec2Input := ec2.CreateVpcEndpointInput{
 		VpcId:         aws.String(input.VpcId),
 		ServiceName:   aws.String(input.ServiceName),
 		RouteTableIds: input.VPCEndpointGatewayConfig.RouteTableIDs,

--- a/pkg/aws/vpcendpoint/client_create.go
+++ b/pkg/aws/vpcendpoint/client_create.go
@@ -68,7 +68,7 @@ func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (outp
 		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
 	}
 	if input.VPCEndpointGatewayConfig != nil && input.VPCEndpointInterfaceConfig != nil {
-		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig and %T.VPCEndpointInterfaceConfig cannot be set both at same time", input)
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig and %T.VPCEndpointInterfaceConfig cannot be set both at same time", input, input)
 	}
 
 	var ec2Input ec2.CreateVpcEndpointInput

--- a/pkg/aws/vpcendpoint/client_create.go
+++ b/pkg/aws/vpcendpoint/client_create.go
@@ -14,21 +14,35 @@ import (
 )
 
 type CreateVpcEndpointInput struct {
-	RoleARN          string
-	Region           string
-	VpcId            string
+	RoleARN     string
+	Region      string
+	ServiceName string
+	Tags        map[string]string
+	Type        ec2Types.VpcEndpointType
+	VpcId       string
+
+	VPCEndpointInterfaceConfig *VPCEndpointInterfaceConfig
+	VPCEndpointGatewayConfig   *VPCEndpointGatewayConfig
+}
+
+type VPCEndpointInterfaceConfig struct {
 	SubnetIds        []string
 	SecurityGroupIds []string
-	Tags             map[string]string
+}
+
+type VPCEndpointGatewayConfig struct {
+	RouteTableIDs []string
 }
 
 type CreateVpcEndpointOutput struct {
-	VpcEndpointId    string
-	VpcEndpointState string
+	VpcEndpointId          string
+	VpcEndpointState       string
+	VpcEndpointType        ec2Types.VpcEndpointType
+	VpcEndpointServiceName string
 }
 
 func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (output CreateVpcEndpointOutput, err error) {
-	logger := log.FromContext(ctx)
+	logger := log.FromContext(ctx).WithValues("vpc-endpoint-type", input.Type).WithValues("service-name", input.ServiceName)
 	logger.Info("Started creating VPC endpoint")
 	defer func() {
 		if err == nil {
@@ -44,33 +58,68 @@ func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (outp
 	if input.Region == "" {
 		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.Region must not be empty", input)
 	}
+	if input.ServiceName == "" {
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.ServiceName must not be empty", input)
+	}
+	if input.Type == "" {
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.Type must not be empty", input)
+	}
 	if input.VpcId == "" {
 		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
 	}
-
-	ec2Input := ec2.CreateVpcEndpointInput{
-		VpcId:       aws.String(input.VpcId),
-		ServiceName: aws.String(secretsManagerServiceName(input.Region)),
-		DnsOptions: &ec2Types.DnsOptionsSpecification{
-			DnsRecordIpType: ec2Types.DnsRecordIpTypeIpv4,
-		},
-		IpAddressType:     ec2Types.IpAddressTypeIpv4,
-		PrivateDnsEnabled: aws.Bool(true),
-		SecurityGroupIds:  input.SecurityGroupIds,
-		SubnetIds:         input.SubnetIds,
-		TagSpecifications: []ec2Types.TagSpecification{
-			tags.BuildParamsToTagSpecification(ec2Types.ResourceTypeVpcEndpoint, input.Tags),
-		},
-		VpcEndpointType: ec2Types.VpcEndpointTypeInterface,
+	if input.VPCEndpointGatewayConfig != nil && input.VPCEndpointInterfaceConfig != nil {
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig and %T.VPCEndpointInterfaceConfig cannot be set both at same time", input)
 	}
+
+	var ec2Input ec2.CreateVpcEndpointInput
+
+	// endpoint type interface
+	if input.Type == ec2Types.VpcEndpointTypeInterface {
+		ec2Input = ec2.CreateVpcEndpointInput{
+			VpcId:       aws.String(input.VpcId),
+			ServiceName: aws.String(input.ServiceName),
+			DnsOptions: &ec2Types.DnsOptionsSpecification{
+				DnsRecordIpType: ec2Types.DnsRecordIpTypeIpv4,
+			},
+			IpAddressType:     ec2Types.IpAddressTypeIpv4,
+			PrivateDnsEnabled: aws.Bool(true),
+			SecurityGroupIds:  input.VPCEndpointInterfaceConfig.SecurityGroupIds,
+			SubnetIds:         input.VPCEndpointInterfaceConfig.SubnetIds,
+			TagSpecifications: []ec2Types.TagSpecification{
+				tags.BuildParamsToTagSpecification(ec2Types.ResourceTypeVpcEndpoint, input.Tags),
+			},
+			VpcEndpointType: input.Type,
+		}
+		// endpoint type gateway
+	} else if input.Type == ec2Types.VpcEndpointTypeGateway {
+		ec2Input = ec2.CreateVpcEndpointInput{
+			VpcId:       aws.String(input.VpcId),
+			ServiceName: aws.String(input.ServiceName),
+			DnsOptions: &ec2Types.DnsOptionsSpecification{
+				DnsRecordIpType: ec2Types.DnsRecordIpTypeIpv4,
+			},
+			RouteTableIds: input.VPCEndpointGatewayConfig.RouteTableIDs,
+			TagSpecifications: []ec2Types.TagSpecification{
+				tags.BuildParamsToTagSpecification(ec2Types.ResourceTypeVpcEndpoint, input.Tags),
+			},
+			VpcEndpointType: input.Type,
+		}
+		// unknown endpoint type
+	} else {
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.Type value is unknown '%s', valid options are Interface or Gateway", input, input.Type)
+
+	}
+
 	ec2Output, err := c.ec2Client.CreateVpcEndpoint(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(input.RoleARN, input.Region))
 	if err != nil {
 		return CreateVpcEndpointOutput{}, microerror.Mask(err)
 	}
 
 	output = CreateVpcEndpointOutput{
-		VpcEndpointId:    *ec2Output.VpcEndpoint.VpcEndpointId,
-		VpcEndpointState: string(ec2Output.VpcEndpoint.State),
+		VpcEndpointId:          *ec2Output.VpcEndpoint.VpcEndpointId,
+		VpcEndpointServiceName: input.ServiceName,
+		VpcEndpointType:        input.Type,
+		VpcEndpointState:       string(ec2Output.VpcEndpoint.State),
 	}
 
 	return output, err

--- a/pkg/aws/vpcendpoint/client_create.go
+++ b/pkg/aws/vpcendpoint/client_create.go
@@ -93,11 +93,8 @@ func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (outp
 		// endpoint type gateway
 	} else if input.Type == ec2Types.VpcEndpointTypeGateway {
 		ec2Input = ec2.CreateVpcEndpointInput{
-			VpcId:       aws.String(input.VpcId),
-			ServiceName: aws.String(input.ServiceName),
-			DnsOptions: &ec2Types.DnsOptionsSpecification{
-				DnsRecordIpType: ec2Types.DnsRecordIpTypeIpv4,
-			},
+			VpcId:         aws.String(input.VpcId),
+			ServiceName:   aws.String(input.ServiceName),
 			RouteTableIds: input.VPCEndpointGatewayConfig.RouteTableIDs,
 			TagSpecifications: []ec2Types.TagSpecification{
 				tags.BuildParamsToTagSpecification(ec2Types.ResourceTypeVpcEndpoint, input.Tags),

--- a/pkg/aws/vpcendpoint/client_create.go
+++ b/pkg/aws/vpcendpoint/client_create.go
@@ -21,13 +21,7 @@ type CreateVpcEndpointInput struct {
 	Type        ec2Types.VpcEndpointType
 	VpcId       string
 
-	VPCEndpointInterfaceConfig *VPCEndpointInterfaceConfig
-	VPCEndpointGatewayConfig   *VPCEndpointGatewayConfig
-}
-
-type VPCEndpointInterfaceConfig struct {
-	SubnetIds        []string
-	SecurityGroupIds []string
+	VPCEndpointGatewayConfig *VPCEndpointGatewayConfig
 }
 
 type VPCEndpointGatewayConfig struct {
@@ -35,10 +29,8 @@ type VPCEndpointGatewayConfig struct {
 }
 
 type CreateVpcEndpointOutput struct {
-	VpcEndpointId          string
-	VpcEndpointState       string
-	VpcEndpointType        ec2Types.VpcEndpointType
-	VpcEndpointServiceName string
+	VpcEndpointId    string
+	VpcEndpointState string
 }
 
 func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (output CreateVpcEndpointOutput, err error) {
@@ -67,44 +59,20 @@ func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (outp
 	if input.VpcId == "" {
 		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
 	}
-	if input.VPCEndpointGatewayConfig != nil && input.VPCEndpointInterfaceConfig != nil {
-		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig and %T.VPCEndpointInterfaceConfig cannot be set both at same time", input, input)
+	if input.VPCEndpointGatewayConfig == nil {
+		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig cannot be nil", input)
 	}
 
 	var ec2Input ec2.CreateVpcEndpointInput
 
-	// endpoint type interface
-	if input.Type == ec2Types.VpcEndpointTypeInterface {
-		ec2Input = ec2.CreateVpcEndpointInput{
-			VpcId:       aws.String(input.VpcId),
-			ServiceName: aws.String(input.ServiceName),
-			DnsOptions: &ec2Types.DnsOptionsSpecification{
-				DnsRecordIpType: ec2Types.DnsRecordIpTypeIpv4,
-			},
-			IpAddressType:     ec2Types.IpAddressTypeIpv4,
-			PrivateDnsEnabled: aws.Bool(true),
-			SecurityGroupIds:  input.VPCEndpointInterfaceConfig.SecurityGroupIds,
-			SubnetIds:         input.VPCEndpointInterfaceConfig.SubnetIds,
-			TagSpecifications: []ec2Types.TagSpecification{
-				tags.BuildParamsToTagSpecification(ec2Types.ResourceTypeVpcEndpoint, input.Tags),
-			},
-			VpcEndpointType: input.Type,
-		}
-		// endpoint type gateway
-	} else if input.Type == ec2Types.VpcEndpointTypeGateway {
-		ec2Input = ec2.CreateVpcEndpointInput{
-			VpcId:         aws.String(input.VpcId),
-			ServiceName:   aws.String(input.ServiceName),
-			RouteTableIds: input.VPCEndpointGatewayConfig.RouteTableIDs,
-			TagSpecifications: []ec2Types.TagSpecification{
-				tags.BuildParamsToTagSpecification(ec2Types.ResourceTypeVpcEndpoint, input.Tags),
-			},
-			VpcEndpointType: input.Type,
-		}
-		// unknown endpoint type
-	} else {
-		return CreateVpcEndpointOutput{}, microerror.Maskf(errors.InvalidConfigError, "%T.Type value is unknown '%s', valid options are Interface or Gateway", input, input.Type)
-
+	ec2Input = ec2.CreateVpcEndpointInput{
+		VpcId:         aws.String(input.VpcId),
+		ServiceName:   aws.String(input.ServiceName),
+		RouteTableIds: input.VPCEndpointGatewayConfig.RouteTableIDs,
+		TagSpecifications: []ec2Types.TagSpecification{
+			tags.BuildParamsToTagSpecification(ec2Types.ResourceTypeVpcEndpoint, input.Tags),
+		},
+		VpcEndpointType: input.Type,
 	}
 
 	ec2Output, err := c.ec2Client.CreateVpcEndpoint(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(input.RoleARN, input.Region))
@@ -113,10 +81,8 @@ func (c *client) Create(ctx context.Context, input CreateVpcEndpointInput) (outp
 	}
 
 	output = CreateVpcEndpointOutput{
-		VpcEndpointId:          *ec2Output.VpcEndpoint.VpcEndpointId,
-		VpcEndpointServiceName: input.ServiceName,
-		VpcEndpointType:        input.Type,
-		VpcEndpointState:       string(ec2Output.VpcEndpoint.State),
+		VpcEndpointId:    *ec2Output.VpcEndpoint.VpcEndpointId,
+		VpcEndpointState: string(ec2Output.VpcEndpoint.State),
 	}
 
 	return output, err

--- a/pkg/aws/vpcendpoint/client_delete.go
+++ b/pkg/aws/vpcendpoint/client_delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -11,13 +12,15 @@ import (
 )
 
 type DeleteVpcEndpointInput struct {
-	RoleARN string
-	Region  string
-	VpcId   string
+	RoleARN     string
+	Region      string
+	ServiceName string
+	Type        ec2Types.VpcEndpointType
+	VpcId       string
 }
 
 func (c *client) Delete(ctx context.Context, input DeleteVpcEndpointInput) (err error) {
-	logger := log.FromContext(ctx)
+	logger := log.FromContext(ctx).WithValues("vpc-endpoint-type", input.Type).WithValues("service-name", input.ServiceName)
 	logger.Info("Started deleting VPC endpoint", "vpc-id", input.VpcId)
 	defer func() {
 		if err == nil {
@@ -32,6 +35,12 @@ func (c *client) Delete(ctx context.Context, input DeleteVpcEndpointInput) (err 
 	}
 	if input.Region == "" {
 		return microerror.Maskf(errors.InvalidConfigError, "%T.Region must not be empty", input)
+	}
+	if input.ServiceName == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.ServiceName must not be empty", input)
+	}
+	if input.Type == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.Type must not be empty", input)
 	}
 	if input.VpcId == "" {
 		return microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)

--- a/pkg/aws/vpcendpoint/client_get.go
+++ b/pkg/aws/vpcendpoint/client_get.go
@@ -21,11 +21,10 @@ type GetVpcEndpointInput struct {
 }
 
 type GetVpcEndpointOutput struct {
-	VpcEndpointId              string
-	VpcEndpointState           string
-	Type                       ec2Types.VpcEndpointType
-	VPCEndpointInterfaceConfig *VPCEndpointInterfaceConfig
-	VPCEndpointGatewayConfig   *VPCEndpointGatewayConfig
+	VpcEndpointId            string
+	VpcEndpointState         string
+	Type                     ec2Types.VpcEndpointType
+	VPCEndpointGatewayConfig *VPCEndpointGatewayConfig
 }
 
 func (c *client) Get(ctx context.Context, input GetVpcEndpointInput) (output GetVpcEndpointOutput, err error) {
@@ -80,33 +79,13 @@ func (c *client) Get(ctx context.Context, input GetVpcEndpointInput) (output Get
 		return GetVpcEndpointOutput{}, microerror.Maskf(errors.VpcEndpointNotFoundError, "VPC %s endpoint %s for VPC %s not found", input.Type, input.ServiceName, input.VpcId)
 	}
 
-	// endpoint type interface
-	if ec2Output.VpcEndpoints[0].VpcEndpointType == ec2Types.VpcEndpointTypeInterface {
-		output = GetVpcEndpointOutput{
-			VpcEndpointId:    *ec2Output.VpcEndpoints[0].VpcEndpointId,
-			VpcEndpointState: string(ec2Output.VpcEndpoints[0].State),
-			VPCEndpointInterfaceConfig: &VPCEndpointInterfaceConfig{
-				SubnetIds: ec2Output.VpcEndpoints[0].SubnetIds,
-			},
-			Type: ec2Output.VpcEndpoints[0].VpcEndpointType,
-		}
-
-		for _, securityGroup := range ec2Output.VpcEndpoints[0].Groups {
-			if securityGroup.GroupId == nil {
-				continue
-			}
-			output.VPCEndpointInterfaceConfig.SecurityGroupIds = append(output.VPCEndpointInterfaceConfig.SecurityGroupIds, *securityGroup.GroupId)
-		}
-		// endpoint type gateway
-	} else if ec2Output.VpcEndpoints[0].VpcEndpointType == ec2Types.VpcEndpointTypeGateway {
-		output = GetVpcEndpointOutput{
-			VpcEndpointId:    *ec2Output.VpcEndpoints[0].VpcEndpointId,
-			VpcEndpointState: string(ec2Output.VpcEndpoints[0].State),
-			VPCEndpointGatewayConfig: &VPCEndpointGatewayConfig{
-				RouteTableIDs: ec2Output.VpcEndpoints[0].RouteTableIds,
-			},
-			Type: ec2Output.VpcEndpoints[0].VpcEndpointType,
-		}
+	output = GetVpcEndpointOutput{
+		VpcEndpointId:    *ec2Output.VpcEndpoints[0].VpcEndpointId,
+		VpcEndpointState: string(ec2Output.VpcEndpoints[0].State),
+		VPCEndpointGatewayConfig: &VPCEndpointGatewayConfig{
+			RouteTableIDs: ec2Output.VpcEndpoints[0].RouteTableIds,
+		},
+		Type: ec2Output.VpcEndpoints[0].VpcEndpointType,
 	}
 
 	return output, err

--- a/pkg/aws/vpcendpoint/client_update.go
+++ b/pkg/aws/vpcendpoint/client_update.go
@@ -63,7 +63,7 @@ func (c *client) Update(ctx context.Context, input UpdateVpcEndpointInput) (err 
 		return microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
 	}
 	if input.VPCEndpointGatewayConfig != nil && input.VPCEndpointInterfaceConfig != nil {
-		return microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig and %T.VPCEndpointInterfaceConfig cannot be set both at same time", input)
+		return microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig and %T.VPCEndpointInterfaceConfig cannot be set both at same time", input, input)
 	}
 
 	if input.Type == ec2Types.VpcEndpointTypeInterface {

--- a/pkg/aws/vpcendpoint/client_update.go
+++ b/pkg/aws/vpcendpoint/client_update.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -13,18 +14,30 @@ import (
 )
 
 type UpdateVpcEndpointInput struct {
-	RoleARN                string
-	Region                 string
-	VpcEndpointId          string
+	RoleARN                    string
+	Region                     string
+	Type                       ec2Types.VpcEndpointType
+	ServiceName                string
+	VpcEndpointId              string
+	VPCEndpointInterfaceConfig *VPCEndpointInterfaceUpdateConfig
+	VPCEndpointGatewayConfig   *VPCEndpointGatewayUpdateConfig
+	Tags                       map[string]string
+}
+
+type VPCEndpointInterfaceUpdateConfig struct {
 	AddSecurityGroupIds    []string
 	AddSubnetIds           []string
 	RemoveSecurityGroupIds []string
 	RemoveSubnetIds        []string
-	Tags                   map[string]string
+}
+
+type VPCEndpointGatewayUpdateConfig struct {
+	AddRouteTableIDs    []string
+	RemoveRouteTableIDs []string
 }
 
 func (c *client) Update(ctx context.Context, input UpdateVpcEndpointInput) (err error) {
-	logger := log.FromContext(ctx)
+	logger := log.FromContext(ctx).WithValues("vpc-endpoint-type", input.Type).WithValues("service-name", input.ServiceName)
 	logger.Info("Started updating VPC endpoint")
 	defer func() {
 		if err == nil {
@@ -40,32 +53,63 @@ func (c *client) Update(ctx context.Context, input UpdateVpcEndpointInput) (err 
 	if input.Region == "" {
 		return microerror.Maskf(errors.InvalidConfigError, "%T.Region must not be empty", input)
 	}
+	if input.ServiceName == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.ServiceName must not be empty", input)
+	}
+	if input.Type == "" {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.Type must not be empty", input)
+	}
 	if input.VpcEndpointId == "" {
 		return microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
 	}
+	if input.VPCEndpointGatewayConfig != nil && input.VPCEndpointInterfaceConfig != nil {
+		return microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig and %T.VPCEndpointInterfaceConfig cannot be set both at same time", input)
+	}
 
-	if atLeastOneIsNotEmpty(input.AddSecurityGroupIds, input.AddSubnetIds, input.RemoveSecurityGroupIds, input.RemoveSubnetIds) {
-		logger.Info("VPC endpoint needs updates",
-			"vpc-endpoint-id", input.VpcEndpointId,
-			"add-security-groups", input.AddSecurityGroupIds,
-			"remove-security-groups", input.RemoveSecurityGroupIds,
-			"add-subnets", input.AddSubnetIds,
-			"remove-subnets", input.RemoveSubnetIds)
+	if input.Type == ec2Types.VpcEndpointTypeInterface {
+		if atLeastOneIsNotEmpty(input.VPCEndpointInterfaceConfig.AddSecurityGroupIds, input.VPCEndpointInterfaceConfig.AddSubnetIds, input.VPCEndpointInterfaceConfig.RemoveSecurityGroupIds, input.VPCEndpointInterfaceConfig.RemoveSubnetIds) {
+			logger.Info("VPC endpoint needs updates",
+				"vpc-endpoint-id", input.VpcEndpointId,
+				"add-security-groups", input.VPCEndpointInterfaceConfig.AddSecurityGroupIds,
+				"remove-security-groups", input.VPCEndpointInterfaceConfig.RemoveSecurityGroupIds,
+				"add-subnets", input.VPCEndpointInterfaceConfig.AddSubnetIds,
+				"remove-subnets", input.VPCEndpointInterfaceConfig.RemoveSubnetIds)
 
-		ec2Input := ec2.ModifyVpcEndpointInput{
-			VpcEndpointId:          aws.String(input.VpcEndpointId),
-			AddSecurityGroupIds:    input.AddSecurityGroupIds,
-			AddSubnetIds:           input.AddSubnetIds,
-			RemoveSecurityGroupIds: input.RemoveSecurityGroupIds,
-			RemoveSubnetIds:        input.RemoveSubnetIds,
-			ResetPolicy:            aws.Bool(true),
+			ec2Input := ec2.ModifyVpcEndpointInput{
+				VpcEndpointId:          aws.String(input.VpcEndpointId),
+				AddSecurityGroupIds:    input.VPCEndpointInterfaceConfig.AddSecurityGroupIds,
+				AddSubnetIds:           input.VPCEndpointInterfaceConfig.AddSubnetIds,
+				RemoveSecurityGroupIds: input.VPCEndpointInterfaceConfig.RemoveSecurityGroupIds,
+				RemoveSubnetIds:        input.VPCEndpointInterfaceConfig.RemoveSubnetIds,
+				ResetPolicy:            aws.Bool(true),
+			}
+			_, err = c.ec2Client.ModifyVpcEndpoint(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(input.RoleARN, input.Region))
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		} else {
+			logger.Info("VPC endpoint is  already up-to-date", "vpc-endpoint-id", input.VpcEndpointId)
 		}
-		_, err = c.ec2Client.ModifyVpcEndpoint(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(input.RoleARN, input.Region))
-		if err != nil {
-			return microerror.Mask(err)
+	} else if input.Type == ec2Types.VpcEndpointTypeGateway {
+		if atLeastOneIsNotEmpty(input.VPCEndpointGatewayConfig.AddRouteTableIDs, input.VPCEndpointGatewayConfig.RemoveRouteTableIDs) {
+			logger.Info("VPC endpoint needs updates",
+				"vpc-endpoint-id", input.VpcEndpointId,
+				"add-route-tables", input.VPCEndpointGatewayConfig.AddRouteTableIDs,
+				"remove-route-tables", input.VPCEndpointGatewayConfig.RemoveRouteTableIDs)
+
+			ec2Input := ec2.ModifyVpcEndpointInput{
+				VpcEndpointId:       aws.String(input.VpcEndpointId),
+				AddRouteTableIds:    input.VPCEndpointGatewayConfig.AddRouteTableIDs,
+				RemoveRouteTableIds: input.VPCEndpointGatewayConfig.RemoveRouteTableIDs,
+				ResetPolicy:         aws.Bool(true),
+			}
+			_, err = c.ec2Client.ModifyVpcEndpoint(ctx, &ec2Input, c.assumeRoleClient.AssumeRoleFunc(input.RoleARN, input.Region))
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		} else {
+			logger.Info("VPC endpoint is  already up-to-date", "vpc-endpoint-id", input.VpcEndpointId)
 		}
-	} else {
-		logger.Info("VPC endpoint is  already up-to-date", "vpc-endpoint-id", input.VpcEndpointId)
 	}
 
 	logger.Info("Updating VPC endpoint tags", "tags", input.Tags)

--- a/pkg/aws/vpcendpoint/client_update.go
+++ b/pkg/aws/vpcendpoint/client_update.go
@@ -55,7 +55,7 @@ func (c *client) Update(ctx context.Context, input UpdateVpcEndpointInput) (err 
 		return microerror.Maskf(errors.InvalidConfigError, "%T.VpcId must not be empty", input)
 	}
 	if input.VPCEndpointGatewayConfig == nil {
-		return microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig cannot be nil", input, input)
+		return microerror.Maskf(errors.InvalidConfigError, "%T.VPCEndpointGatewayConfig cannot be nil", input)
 	}
 
 	if atLeastOneIsNotEmpty(input.VPCEndpointGatewayConfig.AddRouteTableIDs, input.VPCEndpointGatewayConfig.RemoveRouteTableIDs) {

--- a/pkg/aws/vpcendpoint/reconciler_delete.go
+++ b/pkg/aws/vpcendpoint/reconciler_delete.go
@@ -39,25 +39,22 @@ func (r *reconciler) ReconcileDelete(ctx context.Context, request aws.ReconcileR
 		return microerror.Maskf(errors.InvalidConfigError, "%T.Spec.Id must not be empty", request)
 	}
 
-	// s3 endpoint
-	{
-		input := DeleteVpcEndpointInput{
-			RoleARN:     request.RoleARN,
-			Region:      request.Region,
-			VpcId:       request.Spec.Id,
-			Type:        ec2Types.VpcEndpointTypeGateway,
-			ServiceName: s3ServiceName(request.Region),
-		}
-		err = r.client.Delete(ctx, input)
-		if errors.IsVpcEndpointNotFound(err) {
-			logger.Info("Nothing to delete, VPC endpoint not found")
-		} else if errors.IsResourceAlreadyDeleted(err) {
-			logger.Info("Nothing to delete, VPC endpoint already deleted")
-		} else if errors.IsResourceDeletionInProgress(err) {
-			logger.Info("VPC endpoint deletion is already in progress")
-		} else if err != nil {
-			return microerror.Mask(err)
-		}
+	input := DeleteVpcEndpointInput{
+		RoleARN:     request.RoleARN,
+		Region:      request.Region,
+		VpcId:       request.Spec.Id,
+		Type:        ec2Types.VpcEndpointTypeGateway,
+		ServiceName: s3ServiceName(request.Region),
+	}
+	err = r.client.Delete(ctx, input)
+	if errors.IsVpcEndpointNotFound(err) {
+		logger.Info("Nothing to delete, VPC endpoint not found")
+	} else if errors.IsResourceAlreadyDeleted(err) {
+		logger.Info("Nothing to delete, VPC endpoint already deleted")
+	} else if errors.IsResourceDeletionInProgress(err) {
+		logger.Info("VPC endpoint deletion is already in progress")
+	} else if err != nil {
+		return microerror.Mask(err)
 	}
 
 	return nil

--- a/pkg/aws/vpcendpoint/reconciler_delete.go
+++ b/pkg/aws/vpcendpoint/reconciler_delete.go
@@ -39,27 +39,6 @@ func (r *reconciler) ReconcileDelete(ctx context.Context, request aws.ReconcileR
 		return microerror.Maskf(errors.InvalidConfigError, "%T.Spec.Id must not be empty", request)
 	}
 
-	// seceet date endpoint
-	{
-		input := DeleteVpcEndpointInput{
-			RoleARN:     request.RoleARN,
-			Region:      request.Region,
-			VpcId:       request.Spec.Id,
-			Type:        ec2Types.VpcEndpointTypeInterface,
-			ServiceName: secretsManagerServiceName(request.Region),
-		}
-		err = r.client.Delete(ctx, input)
-		if errors.IsVpcEndpointNotFound(err) {
-			logger.Info("Nothing to delete, VPC endpoint not found")
-		} else if errors.IsResourceAlreadyDeleted(err) {
-			logger.Info("Nothing to delete, VPC endpoint already deleted")
-		} else if errors.IsResourceDeletionInProgress(err) {
-			logger.Info("VPC endpoint deletion is already in progress")
-		} else if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
 	// s3 endpoint
 	{
 		input := DeleteVpcEndpointInput{

--- a/pkg/aws/vpcendpoint/reconciler_normal.go
+++ b/pkg/aws/vpcendpoint/reconciler_normal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	capa "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
@@ -21,11 +22,14 @@ type Spec struct {
 	SubnetIds        []string
 	SecurityGroupIds []string
 	AdditionalTags   map[string]string
+	RouteTableIds    []string
 }
 
 type Status struct {
-	VpcEndpointId    string
-	VpcEndpointState string
+	VpcEndpointId          string
+	VpcEndpointState       string
+	VpcEndpointType        ec2Types.VpcEndpointType
+	VpcEndpointServiceName string
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request aws.ReconcileRequest[Spec]) (result aws.ReconcileResult[Status], err error) {
@@ -63,78 +67,163 @@ func (r *reconciler) Reconcile(ctx context.Context, request aws.ReconcileRequest
 		Status: Status{},
 	}
 
-	// Get existing VPC endpoint
-	getInput := GetVpcEndpointInput{
-		RoleARN: request.RoleARN,
-		Region:  request.Region,
-		VpcId:   request.Spec.VpcId,
-	}
-	getOutput, err := r.client.Get(ctx, getInput)
-	if errors.IsVpcEndpointNotFound(err) {
-		// VPC endpoint not found, so we create one
-		createInput := CreateVpcEndpointInput{
-			RoleARN:          request.RoleARN,
-			Region:           request.Region,
-			VpcId:            request.Spec.VpcId,
-			SubnetIds:        request.Spec.SubnetIds,
-			SecurityGroupIds: request.Spec.SecurityGroupIds,
-			Tags:             r.getVpcEndpointTags(request.ClusterName, request.Spec.VpcId, "", request.Region, request.AdditionalTags),
+	// secretmanager interface endpoint
+	{
+		// Get existing VPC endpoint
+		getInput := GetVpcEndpointInput{
+			RoleARN:     request.RoleARN,
+			Region:      request.Region,
+			Type:        ec2Types.VpcEndpointTypeInterface,
+			ServiceName: secretsManagerServiceName(request.Region),
+			VpcId:       request.Spec.VpcId,
 		}
-		createOutput, err := r.client.Create(ctx, createInput)
-		if err != nil {
+		getOutput, err := r.client.Get(ctx, getInput)
+		if errors.IsVpcEndpointNotFound(err) {
+			// VPC endpoint not found, so we create one
+			createInput := CreateVpcEndpointInput{
+				RoleARN:     request.RoleARN,
+				Region:      request.Region,
+				Type:        ec2Types.VpcEndpointTypeInterface,
+				ServiceName: secretsManagerServiceName(request.Region),
+				VpcId:       request.Spec.VpcId,
+				VPCEndpointInterfaceConfig: &VPCEndpointInterfaceConfig{
+					SubnetIds:        request.Spec.SubnetIds,
+					SecurityGroupIds: request.Spec.SecurityGroupIds,
+				},
+				Tags: r.getVpcEndpointTags(request.ClusterName, request.Spec.VpcId, "", request.Region, request.AdditionalTags),
+			}
+			createOutput, err := r.client.Create(ctx, createInput)
+			if err != nil {
+				return aws.ReconcileResult[Status]{}, microerror.Mask(err)
+			}
+
+			result.Status = Status(createOutput)
+		} else if err != nil {
 			return aws.ReconcileResult[Status]{}, microerror.Mask(err)
-		}
+		} else {
+			// Sort current securityGroupIds and subnetIds, so we can use sort.SearchStrings
+			// when checking difference in slices.
+			// This modifies slice in-place, but we just use it here anyway, so that's
+			// fine.
+			currentSecurityGroupIds := cloneAndSort(getOutput.VPCEndpointInterfaceConfig.SecurityGroupIds)
+			wantedSecurityGroupIds := cloneAndSort(request.Spec.SecurityGroupIds)
+			currentSubnetIds := cloneAndSort(getOutput.VPCEndpointInterfaceConfig.SubnetIds)
+			wantedSubnetIds := cloneAndSort(request.Spec.SubnetIds)
 
-		result.Status = Status(createOutput)
-		return result, nil
-	} else if err != nil {
-		return aws.ReconcileResult[Status]{}, microerror.Mask(err)
-	} else {
-		// Sort current securityGroupIds and subnetIds, so we can use sort.SearchStrings
-		// when checking difference in slices.
-		// This modifies slice in-place, but we just use it here anyway, so that's
-		// fine.
-		currentSecurityGroupIds := cloneAndSort(getOutput.SecurityGroupIds)
-		wantedSecurityGroupIds := cloneAndSort(request.Spec.SecurityGroupIds)
-		currentSubnetIds := cloneAndSort(getOutput.SubnetIds)
-		wantedSubnetIds := cloneAndSort(request.Spec.SubnetIds)
+			// securityGroupIDs that we will add, those specified in the input, but not
+			// already present in current state
+			securityGroupIdsToBeAdded := diff(wantedSecurityGroupIds, currentSecurityGroupIds)
 
-		// securityGroupIDs that we will add, those specified in the input, but not
-		// already present in current state
-		securityGroupIdsToBeAdded := diff(wantedSecurityGroupIds, currentSecurityGroupIds)
+			// securityGroupIDs that we will remove, those already in the current state,
+			// but not present in the input
+			securityGroupIdsToBeRemoved := diff(currentSecurityGroupIds, wantedSecurityGroupIds)
 
-		// securityGroupIDs that we will remove, those already in the current state,
-		// but not present in the input
-		securityGroupIdsToBeRemoved := diff(currentSecurityGroupIds, wantedSecurityGroupIds)
+			// subnets that we will add, those specified in the input, but not already
+			// present in current state
+			subnetIdsToBeAdded := diff(wantedSubnetIds, currentSubnetIds)
 
-		// subnets that we will add, those specified in the input, but not already
-		// present in current state
-		subnetIdsToBeAdded := diff(wantedSubnetIds, currentSubnetIds)
+			// subnets that we will remove, those already in the current state, but not
+			// present in the input
+			subnetIdsToBeRemoved := diff(currentSubnetIds, wantedSubnetIds)
 
-		// subnets that we will remove, those already in the current state, but not
-		// present in the input
-		subnetIdsToBeRemoved := diff(currentSubnetIds, wantedSubnetIds)
+			updateInput := UpdateVpcEndpointInput{
+				RoleARN:       request.RoleARN,
+				Region:        request.Region,
+				VpcEndpointId: getOutput.VpcEndpointId,
+				VPCEndpointInterfaceConfig: &VPCEndpointInterfaceUpdateConfig{
+					AddSecurityGroupIds:    securityGroupIdsToBeAdded,
+					AddSubnetIds:           subnetIdsToBeAdded,
+					RemoveSecurityGroupIds: securityGroupIdsToBeRemoved,
+					RemoveSubnetIds:        subnetIdsToBeRemoved,
+				},
+				Type:        ec2Types.VpcEndpointTypeInterface,
+				ServiceName: secretsManagerServiceName(request.Region),
+				Tags:        r.getVpcEndpointTags(request.ClusterName, request.Spec.VpcId, getOutput.VpcEndpointId, request.Region, request.AdditionalTags),
+			}
 
-		updateInput := UpdateVpcEndpointInput{
-			RoleARN:                request.RoleARN,
-			Region:                 request.Region,
-			VpcEndpointId:          getOutput.VpcEndpointId,
-			AddSecurityGroupIds:    securityGroupIdsToBeAdded,
-			AddSubnetIds:           subnetIdsToBeAdded,
-			RemoveSecurityGroupIds: securityGroupIdsToBeRemoved,
-			RemoveSubnetIds:        subnetIdsToBeRemoved,
-			Tags:                   r.getVpcEndpointTags(request.ClusterName, request.Spec.VpcId, getOutput.VpcEndpointId, request.Region, request.AdditionalTags),
-		}
-
-		err = r.client.Update(ctx, updateInput)
-		if err != nil {
-			return aws.ReconcileResult[Status]{}, microerror.Mask(err)
+			err = r.client.Update(ctx, updateInput)
+			if err != nil {
+				return aws.ReconcileResult[Status]{}, microerror.Mask(err)
+			}
+			result.Status = Status{
+				VpcEndpointId:    getOutput.VpcEndpointId,
+				VpcEndpointState: getOutput.VpcEndpointState,
+			}
 		}
 	}
 
-	result.Status = Status{
-		VpcEndpointId:    getOutput.VpcEndpointId,
-		VpcEndpointState: getOutput.VpcEndpointState,
+	// s3 gateway endpoint
+	{
+		// Get existing VPC endpoint
+		getInput := GetVpcEndpointInput{
+			RoleARN:     request.RoleARN,
+			Region:      request.Region,
+			Type:        ec2Types.VpcEndpointTypeGateway,
+			ServiceName: s3ServiceName(request.Region),
+			VpcId:       request.Spec.VpcId,
+		}
+		getOutput, err := r.client.Get(ctx, getInput)
+		if errors.IsVpcEndpointNotFound(err) {
+			// VPC endpoint not found, so we create one
+			createInput := CreateVpcEndpointInput{
+				RoleARN:     request.RoleARN,
+				Region:      request.Region,
+				Type:        ec2Types.VpcEndpointTypeGateway,
+				ServiceName: s3ServiceName(request.Region),
+				VpcId:       request.Spec.VpcId,
+				VPCEndpointGatewayConfig: &VPCEndpointGatewayConfig{
+					RouteTableIDs: request.Spec.RouteTableIds,
+				},
+				Tags: r.getVpcEndpointTags(request.ClusterName, request.Spec.VpcId, "", request.Region, request.AdditionalTags),
+			}
+			createOutput, err := r.client.Create(ctx, createInput)
+			if err != nil {
+				return aws.ReconcileResult[Status]{}, microerror.Mask(err)
+			}
+
+			result.Status = Status(createOutput)
+		} else if err != nil {
+			return aws.ReconcileResult[Status]{}, microerror.Mask(err)
+		} else {
+			// Sort current routeTablesID, so we can use sort.SearchStrings
+			// when checking difference in slices.
+			// This modifies slice in-place, but we just use it here anyway, so that's
+			// fine.
+			currentRouteTableIds := cloneAndSort(getOutput.VPCEndpointGatewayConfig.RouteTableIDs)
+			wantedRouteTableIds := cloneAndSort(request.Spec.RouteTableIds)
+
+			// securityGroupIDs that we will add, those specified in the input, but not
+			// already present in current state
+			routeTableIdsToBeAdded := diff(wantedRouteTableIds, currentRouteTableIds)
+
+			// securityGroupIDs that we will remove, those already in the current state,
+			// but not present in the input
+			routeTableIdsToBeRemoved := diff(currentRouteTableIds, wantedRouteTableIds)
+
+			updateInput := UpdateVpcEndpointInput{
+				RoleARN:       request.RoleARN,
+				Region:        request.Region,
+				VpcEndpointId: getOutput.VpcEndpointId,
+				VPCEndpointGatewayConfig: &VPCEndpointGatewayUpdateConfig{
+					AddRouteTableIDs:    routeTableIdsToBeAdded,
+					RemoveRouteTableIDs: routeTableIdsToBeRemoved,
+				},
+				Type:        ec2Types.VpcEndpointTypeGateway,
+				ServiceName: s3ServiceName(request.Region),
+				Tags:        r.getVpcEndpointTags(request.ClusterName, request.Spec.VpcId, getOutput.VpcEndpointId, request.Region, request.AdditionalTags),
+			}
+
+			err = r.client.Update(ctx, updateInput)
+			if err != nil {
+				return aws.ReconcileResult[Status]{}, microerror.Mask(err)
+			}
+			result.Status = Status{
+				VpcEndpointId:          getOutput.VpcEndpointId,
+				VpcEndpointState:       getOutput.VpcEndpointState,
+				VpcEndpointServiceName: s3ServiceName(request.Region),
+				VpcEndpointType:        ec2Types.VpcEndpointTypeGateway,
+			}
+		}
 	}
 	return result, nil
 }


### PR DESCRIPTION
add support for VPC endpoint for `s3` service

towards https://github.com/giantswarm/giantswarm/issues/27594


I also realized we no longer need the `secretmanager` VPC endpoint as that was for ubuntu  and Flatcar is using s3 instead 