### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
+
 ### Changed
 
 - Configure `gsoci.azurecr.io` as the default container image registry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [0.5.0] - 2023-07-20
 

--- a/helm/aws-vpc-operator/values.yaml
+++ b/helm/aws-vpc-operator/values.yaml
@@ -6,7 +6,7 @@ project:
   commit: "[[ .SHA ]]"
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/aws-vpc-operator
   tag: "[[ .Version ]]"
   pullPolicy: IfNotPresent
@@ -38,7 +38,7 @@ securityContext:
     type: RuntimeDefault
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
