### PR TITLE
Remove unsetting of subnet ID since `AWSCluster` CRD had a breaking change and requires the field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Go dependencies for CAPI/CAPA/controller-runtime
 
+### Fixed
+
+- Remove unsetting of subnet ID since `AWSCluster` CRD had a breaking change and requires the field
+
 ## [0.7.0] - 2024-06-27
 
 ### Changed

--- a/controllers/awscluster_controller.go
+++ b/controllers/awscluster_controller.go
@@ -710,10 +710,6 @@ func (r *AWSClusterReconciler) reconcileDelete(ctx context.Context, logger logr.
 		if err != nil {
 			return ctrl.Result{}, microerror.Mask(err)
 		}
-		// remove subnet IDs
-		for i := range awsCluster.Spec.NetworkSpec.Subnets {
-			awsCluster.Spec.NetworkSpec.Subnets[i].ID = ""
-		}
 		conditions.MarkFalse(awsCluster, capa.SubnetsReadyCondition, capi.DeletedReason, capi.ConditionSeverityInfo, "Subnets have been deleted")
 		logger.Info("Deleted subnets")
 	}


### PR DESCRIPTION
### What this PR does / why we need it

Fixes https://github.com/giantswarm/roadmap/issues/3577.

Manually tested on `goat` with a workload cluster. After this, we should be able to [re-enable private cluster E2E tests](https://github.com/giantswarm/cluster-test-suites/pull/398).

### Checklist

- [x] Update changelog in CHANGELOG.md.
